### PR TITLE
Fix dol Issue #18: use dol.wrapped_self in PyFilesReader/SetupCfgReader/PyprojectReader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 keywords = []
 authors = []
 dependencies = [
-    "dol",
+    "dol>=0.3.49",
     "config2py",
     "typing_extensions",
     "tomli; python_version < '3.11'",

--- a/tests/test_issue18_wrapped_self.py
+++ b/tests/test_issue18_wrapped_self.py
@@ -18,7 +18,8 @@ def test_is_pkg_and_init_file_contents(tmp_path):
     reader = PyFilesReader(str(pkg))
     # is_pkg reads the relativized outer key '__init__.py' (was False under Issue #18)
     assert reader.is_pkg() is True
-    assert reader.init_file_contents() == "VERSION = '1.0'\n"
+    # normalize newlines: Windows text-mode writes CRLF
+    assert reader.init_file_contents().replace("\r\n", "\n") == "VERSION = '1.0'\n"
 
     nonpkg = tmp_path / "nopkg"
     nonpkg.mkdir()

--- a/tests/test_issue18_wrapped_self.py
+++ b/tests/test_issue18_wrapped_self.py
@@ -1,0 +1,54 @@
+"""Regression tests for dol Issue #18 in xdol's py stores.
+
+Methods defined on a ``wrap_kvs``/``filt_iter``/relative-path-wrapped class run with
+``self`` bound to the inner, unwrapped store, so key relativization and key filtering are
+bypassed. The fix routes those internal accesses through ``dol.wrapped_self(self)`` (the
+outer, transform-applying store). These tests pin the corrected behavior.
+"""
+
+from xdol.pystores import PyFilesReader, SetupCfgReader, PyprojectReader
+
+
+def test_is_pkg_and_init_file_contents(tmp_path):
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("VERSION = '1.0'\n")
+    (pkg / "mod.py").write_text("x = 1\n")
+
+    reader = PyFilesReader(str(pkg))
+    # is_pkg reads the relativized outer key '__init__.py' (was False under Issue #18)
+    assert reader.is_pkg() is True
+    assert reader.init_file_contents() == "VERSION = '1.0'\n"
+
+    nonpkg = tmp_path / "nopkg"
+    nonpkg.mkdir()
+    (nonpkg / "mod.py").write_text("y = 2\n")
+    reader2 = PyFilesReader(str(nonpkg))
+    assert reader2.is_pkg() is False
+    assert reader2.init_file_contents() is None
+
+
+def test_setupcfg_reader_honors_filter_with_decoy(tmp_path):
+    proj = tmp_path / "proj1"
+    proj.mkdir()
+    (proj / "setup.cfg").write_text("[options]\ninstall_requires = requests")
+    # A decoy .cfg that is NOT setup.cfg but would yield a dependency if the filter leaked.
+    (proj / "other.cfg").write_text("[options]\ninstall_requires = SHOULD_NOT_APPEAR")
+
+    reader = SetupCfgReader(str(tmp_path))
+    deps = list(reader.dependencies_from_all())
+    assert "requests" in deps
+    assert "SHOULD_NOT_APPEAR" not in deps  # decoy leaked under Issue #18
+
+
+def test_pyproject_reader_honors_filter_with_decoy(tmp_path):
+    proj = tmp_path / "proj1"
+    proj.mkdir()
+    (proj / "pyproject.toml").write_text('[project]\ndependencies = ["requests>=2.0"]')
+    # A decoy .toml whose basename != pyproject.toml; must not leak into results.
+    (proj / "decoy.toml").write_text('[project]\ndependencies = ["DECOY"]')
+
+    reader = PyprojectReader(str(tmp_path))
+    deps = list(reader.dependencies_from_all())
+    assert any(d.startswith("requests") for d in deps)
+    assert "DECOY" not in deps  # decoy leaked under Issue #18

--- a/xdol/pystores.py
+++ b/xdol/pystores.py
@@ -3,7 +3,7 @@
 import site
 import os
 from functools import wraps
-from dol import wrap_kvs, filt_iter, KvReader, cached_keys, Pipe, Files
+from dol import wrap_kvs, filt_iter, KvReader, cached_keys, Pipe, Files, wrapped_self
 from dol.filesys import mk_relative_path_store, DirCollection, FileBytesReader
 from xdol.util import resolve_to_folder
 
@@ -60,11 +60,14 @@ class PyFilesReader(FileBytesReader, KvReader):
 
     def init_file_contents(self):
         """Returns the string of contents of the __init__.py file if it exists, and None if not"""
-        return self.get("__init__.py", None)
+        # wrapped_self: inside a wrap_kvs/filt_iter/relative-path-wrapped class, ``self`` is
+        # the inner (unwrapped) store whose keys are absolute paths, so ``self.get`` would
+        # miss the relativized '__init__.py' key (dol Issue #18).
+        return wrapped_self(self).get("__init__.py", None)
 
     def is_pkg(self):
         """Returns True if, and only if, the root is a pkg folder (i.e. has an __init__.py file)"""
-        return "__init__.py" in self
+        return "__init__.py" in wrapped_self(self)
 
 
 # TODO: Make it work
@@ -180,7 +183,9 @@ class SetupCfgReader(FileBytesReader, KvReader):
                 # Skip malformed config files
                 pass
 
-        for cfg_content in self.values():
+        # wrapped_self: iterate the OUTER (filtered + relativized) store; ``self.values()``
+        # here would hit the inner store and bypass the _is_setup_cfg filter (dol Issue #18).
+        for cfg_content in wrapped_self(self).values():
             yield from _extract_from_file(cfg_content)
 
 
@@ -259,5 +264,7 @@ class PyprojectReader(FileBytesReader, KvReader):
                 # Skip malformed TOML files
                 pass
 
-        for toml_content in self.values():
+        # wrapped_self: iterate the OUTER (filtered + relativized) store; ``self.values()``
+        # here would hit the inner store and bypass the _is_pyproject_toml filter (Issue #18).
+        for toml_content in wrapped_self(self).values():
             yield from _extract_from_file(toml_content)


### PR DESCRIPTION
## What

Fixes four latent bugs from [dol Issue #18](https://github.com/i2mint/dol/issues/18) (methods on a `wrap_kvs`/`filt_iter`/relative-path-wrapped class run with `self` = the inner **unwrapped** store, bypassing key relativization + filtering):

- `PyFilesReader.is_pkg()` returned **`False` for a real package** (`'__init__.py' in self` tested the inner store's absolute-path keys).
- `PyFilesReader.init_file_contents()` returned `None` for a package, same cause.
- `SetupCfgReader.dependencies_from_all()` / `PyprojectReader.dependencies_from_all()` **leaked dependencies from decoy `.cfg`/`.toml` files** (`self.values()` iterated the unfiltered inner store).

## How

Route those internal accesses through `dol.wrapped_self(self)` — the outer, transform-applying store. Requires **`dol>=0.3.49`** (ships `wrapped_self`).

## Tests

Adds `tests/test_issue18_wrapped_self.py` with decoy-file regression tests (a non-`setup.cfg` `.cfg` and a non-`pyproject.toml` `.toml` that must NOT leak into results, plus is_pkg/init_file_contents on real package/non-package dirs). All pass. (Two pre-existing malformed doctests in `pystores.py` are unrelated and not run by CI.)

Refs i2mint/dol#18

https://claude.ai/code/session_01H8PmV6xmMhzV64zi1Twraw